### PR TITLE
Update .gitignore and twitter.txt with new entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .bsp
 project
 target
+data

--- a/data/twitter.txt
+++ b/data/twitter.txt
@@ -1,4 +1,4 @@
-consumerKey
-consumerSecret
-accessToken
-accessTokenSecret
+consumerKey ZXnntf48AzdoqoSMknwi1EuBF
+consumerSecret c1sHM0Mfv4C2wNnqNfz1bMqLNcAiFQf6cCBSOjrSxaVrkOp4fr
+accessToken 195885707-YG9n5P6ABzMmiVkTLXYxWBQncLppGuxDgrFOATmY
+accessTokenSecret fXvveo6e7UexmbsAbVga0wy3sx5ZxpEeb3hlOatAbryNa


### PR DESCRIPTION
This pull request updates the `data/twitter.txt` file by replacing placeholder values for Twitter API credentials with actual keys and tokens.

* [`data/twitter.txt`](diffhunk://#diff-1b4f58e5fa2e328c8e11912b9a0f6cfa78041cd28b8c28a5ed73a7753b7b0809L1-R4): Updated the `consumerKey`, `consumerSecret`, `accessToken`, and `accessTokenSecret` with actual credential values.