### PR TITLE
Feature/average tweet length

### DIFF
--- a/src/main/scala/com/sundogsoftware/sparkstreaming/AverageTweetLength.scala
+++ b/src/main/scala/com/sundogsoftware/sparkstreaming/AverageTweetLength.scala
@@ -1,69 +1,112 @@
 package com.sundogsoftware.sparkstreaming
 
 import org.apache.spark._
-import org.apache.spark.SparkContext._
 import org.apache.spark.streaming._
-import org.apache.spark.streaming.twitter._
 import org.apache.spark.streaming.StreamingContext._
 import Utilities._
 import java.util.concurrent._
 import java.util.concurrent.atomic._
+import java.io.File
+import scala.collection.mutable
+import org.apache.spark.rdd.RDD
 
 /** Uses thread-safe counters to keep track of the average length of
  *  Tweets in a stream.
  */
 object AverageTweetLength {
-  
+
   /** Our main function where the action happens */
   def main(args: Array[String]) {
-
-    // Configure Twitter credentials using twitter.txt
-    setupTwitter()
-    
-    // Set up a Spark streaming context named "AverageTweetLength" that runs locally using
-    // all CPU cores and one-second batches of data
-    val ssc = new StreamingContext("local[*]", "AverageTweetLength", Seconds(1))
-    
     // Get rid of log spam (should be called after the context is set up)
     setupLogging()
 
-    // Create a DStream from Twitter using our streaming context
-    val tweets = TwitterUtils.createStream(ssc, None)
-    
-    // Now extract the text of each status update into DStreams using map()
-    val statuses = tweets.map(status => status.getText())
-    
-    // Map this to tweet character lengths.
-    val lengths = statuses.map(status => status.length())
-    
-    // As we could have multiple processes adding into these running totals
-    // at the same time, we'll just Java's AtomicLong class to make sure
-    // these counters are thread-safe.
+    // Set up Spark context
+    val conf = new SparkConf().setAppName("AverageTweetLength").setMaster("local[*]")
+    val sc = new SparkContext(conf)
+
+    // Set up Spark streaming context with 1-second batches
+    val ssc = new StreamingContext(sc, Seconds(1))
+
+    // Create a queue of RDDs to stream from
+    val rddQueue = new mutable.Queue[RDD[String]]()
+
+    // Find all tweet directories matching the pattern
+    val rootDir = new File("checkpoint")
+
+    if (!rootDir.exists()) {
+      println(s"Directory ${rootDir.getAbsolutePath} does not exist")
+      System.exit(1)
+    }
+
+    val tweetDirs = rootDir.listFiles()
+      .filter(_.isDirectory)
+      .filter(_.getName.startsWith("Tweets_"))
+      .sortBy(_.getName)
+
+    if (tweetDirs.isEmpty) {
+      println(s"No directories matching the pattern 'Tweets_*' found in ${rootDir.getAbsolutePath}")
+      System.exit(1)
+    }
+
+    println(s"Found ${tweetDirs.length} tweet directories:")
+    tweetDirs.foreach(dir => println(s" - ${dir.getName}"))
+
+    // Collect all tweet files from all directories - looking for part-* files instead of .txt files
+    val tweetFiles = tweetDirs.flatMap { dir =>
+      val files = dir.listFiles()
+      if (files == null) {
+        println(s"Warning: Cannot access directory ${dir.getPath}")
+        Array.empty[File]
+      } else {
+        // Looking for files that start with "part-" instead of ending with ".txt"
+        val partFiles = files.filter(_.isFile).filter(_.getName.startsWith("part-"))
+        println(s"Found ${partFiles.length} tweet files in ${dir.getName}")
+        partFiles
+      }
+    }.sortBy(f => (f.getParentFile.getName, f.getName))
+
+    if (tweetFiles.isEmpty) {
+      println("No tweet files found in any directory")
+      System.exit(1)
+    }
+
+    println(s"Found ${tweetFiles.length} tweet files in total")
+
+    // Load each file into an RDD and add to the queue
+    tweetFiles.foreach { file =>
+      println(s"Loading tweets from ${file.getPath}")
+      val rdd = sc.textFile(file.getPath)
+      val count = rdd.count()
+      println(s" - File contains $count tweets")
+      if (count > 0) {
+        rddQueue += rdd
+      }
+    }
+
+    // Create a DStream from the queue
+    val tweets = ssc.queueStream(rddQueue, oneAtATime = true)
+
+    // Map to character lengths
+    val lengths = tweets.map(status => status.length)
+
+    // Thread-safe counters
     var totalTweets = new AtomicLong(0)
     var totalChars = new AtomicLong(0)
-    
-    // In Spark 1.6+, you  might also look into the mapWithState function, which allows
-    // you to safely and efficiently keep track of global state with key/value pairs.
-    // We'll do that later in the course.
-    
+
     lengths.foreachRDD((rdd, time) => {
-      
       var count = rdd.count()
       if (count > 0) {
         totalTweets.getAndAdd(count)
-        
-        totalChars.getAndAdd(rdd.reduce((x,y) => x + y))
-        
-        println("Total tweets: " + totalTweets.get() + 
-            " Total characters: " + totalChars.get() + 
-            " Average: " + totalChars.get() / totalTweets.get())
+        totalChars.getAndAdd(rdd.map(_.toLong).reduce(_ + _))
+        println("Total tweets: " + totalTweets.get() +
+          " Total characters: " + totalChars.get() +
+          " Average: " + totalChars.get() / totalTweets.get())
       }
     })
-    
+
     // Set a checkpoint directory, and kick it all off
-    // I could watch this all day!
-    ssc.checkpoint("C:/checkpoint/")
+    ssc.checkpoint("checkpoint/average/")
     ssc.start()
     ssc.awaitTermination()
-  }  
+  }
 }

--- a/src/main/scala/com/sundogsoftware/sparkstreaming/LongestTweetLength.scala
+++ b/src/main/scala/com/sundogsoftware/sparkstreaming/LongestTweetLength.scala
@@ -1,0 +1,120 @@
+package com.sundogsoftware.sparkstreaming
+
+import org.apache.spark._
+import org.apache.spark.streaming._
+import org.apache.spark.streaming.StreamingContext._
+import Utilities._
+import java.util.concurrent._
+import java.util.concurrent.atomic._
+import java.io.File
+import scala.collection.mutable
+import org.apache.spark.rdd.RDD
+
+/** Uses thread-safe counters to keep track of the longest
+ *  Tweet in a stream.
+ */
+object LongestTweetLength {
+
+  /** Our main function where the action happens */
+  def main(args: Array[String]) {
+    // Get rid of log spam (should be called after the context is set up)
+    setupLogging()
+
+    // Set up Spark context
+    val conf = new SparkConf().setAppName("LongestTweetLength").setMaster("local[*]")
+    val sc = new SparkContext(conf)
+
+    // Set up Spark streaming context with 1-second batches
+    val ssc = new StreamingContext(sc, Seconds(1))
+
+    // Create a queue of RDDs to stream from
+    val rddQueue = new mutable.Queue[RDD[String]]()
+
+    // Find all tweet directories matching the pattern
+    val rootDir = new File("checkpoint")
+
+    if (!rootDir.exists()) {
+      println(s"Directory ${rootDir.getAbsolutePath} does not exist")
+      System.exit(1)
+    }
+
+    val tweetDirs = rootDir.listFiles()
+      .filter(_.isDirectory)
+      .filter(_.getName.startsWith("Tweets_"))
+      .sortBy(_.getName)
+
+    if (tweetDirs.isEmpty) {
+      println(s"No directories matching the pattern 'Tweets_*' found in ${rootDir.getAbsolutePath}")
+      System.exit(1)
+    }
+
+    println(s"Found ${tweetDirs.length} tweet directories:")
+    tweetDirs.foreach(dir => println(s" - ${dir.getName}"))
+
+    // Collect all tweet files from all directories - looking for part-* files instead of .txt files
+    val tweetFiles = tweetDirs.flatMap { dir =>
+      val files = dir.listFiles()
+      if (files == null) {
+        println(s"Warning: Cannot access directory ${dir.getPath}")
+        Array.empty[File]
+      } else {
+        // Looking for files that start with "part-" instead of ending with ".txt"
+        val partFiles = files.filter(_.isFile).filter(_.getName.startsWith("part-"))
+        println(s"Found ${partFiles.length} tweet files in ${dir.getName}")
+        partFiles
+      }
+    }.sortBy(f => (f.getParentFile.getName, f.getName))
+
+    if (tweetFiles.isEmpty) {
+      println("No tweet files found in any directory")
+      System.exit(1)
+    }
+
+    println(s"Found ${tweetFiles.length} tweet files in total")
+
+    // Load each file into an RDD and add to the queue
+    tweetFiles.foreach { file =>
+      println(s"Loading tweets from ${file.getPath}")
+      val rdd = sc.textFile(file.getPath)
+      val count = rdd.count()
+      println(s" - File contains $count tweets")
+      if (count > 0) {
+        rddQueue += rdd
+      }
+    }
+
+    // Create a DStream from the queue
+    val tweets = ssc.queueStream(rddQueue, oneAtATime = true)
+
+    // Map to character lengths
+    val lengths = tweets.map(status => status.length)
+
+    // Thread-safe counters
+    var totalTweets = new AtomicLong(0)
+    var maxTweetLength = new AtomicLong(0)
+
+    lengths.foreachRDD((rdd, time) => {
+      var count = rdd.count()
+      if (count > 0) {
+        totalTweets.getAndAdd(count)
+
+        // Find the maximum length in this RDD
+        val maxInRdd = rdd.reduce((a, b) => Math.max(a, b))
+
+        // Update the global maximum if needed - simpler approach
+        val currentMax = maxTweetLength.get()
+        if (maxInRdd > currentMax) {
+          maxTweetLength.compareAndSet(currentMax, maxInRdd)
+        }
+
+        println("Total tweets: " + totalTweets.get() +
+          " Longest tweet: " + maxTweetLength.get() + " characters")
+      }
+    })
+
+    // Set a checkpoint directory, and kick it all off
+    ssc.checkpoint("checkpoint/longest/")
+    ssc.start()
+    ssc.awaitTermination()
+  }
+}

--- a/src/main/scala/com/sundogsoftware/sparkstreaming/PopularHashtags.scala
+++ b/src/main/scala/com/sundogsoftware/sparkstreaming/PopularHashtags.scala
@@ -10,7 +10,7 @@ import java.io.File
 import scala.collection.mutable
 
 /** Listens to a stream of Tweets and keeps track of the most popular
- *  hashtags over a 5 minute window.
+ *  words over a 5 minute window.
  */
 object PopularHashtags {
 
@@ -33,9 +33,9 @@ object PopularHashtags {
 
     // Set up a Spark streaming context named "PopularHashtags" that runs locally using
     // all CPU cores and one-second batches of data
-    val conf = new SparkConf().setAppName("PopularHashtags").setMaster("local[*]")
+    val conf = new SparkConf().setAppName("PopularWords").setMaster("local[*]")
     val sc = new SparkContext(conf)
-    val ssc = new StreamingContext(sc, slideSize)
+    val ssc = new StreamingContext(sc, batchSize)
 
     // Create a queue of RDDs to stream from
     val rddQueue = new mutable.Queue[RDD[String]]()
@@ -99,26 +99,40 @@ object PopularHashtags {
     // Now extract the text of each status update into DStreams using map()
     val statuses = tweets.map(status => status)
 
-    // Blow out each word into a new DStream
-    val tweetwords = statuses.flatMap(tweetText => tweetText.split(" "))
+    // Define stop words to filter out
+    val stopWords = Set("a", "an", "the", "in", "on", "at", "to", "for", "with", "by",
+      "of", "and", "or", "is", "are", "was", "were", "be", "been",
+      "this", "that", "it", "i", "you", "he", "she", "they", "we",
+      "rt", "http", "https", "com", "amp")
 
-    // Now eliminate anything that's not a hashtag
-    val hashtags = tweetwords.filter(word => word.startsWith("#"))
+    // Split tweets into words, clean them and filter out stop words and short words
+    val tweetwords = statuses.flatMap(tweetText => {
+      // Convert to lowercase and remove punctuation
+      val text = tweetText.toLowerCase()
+        .replaceAll("[^a-zA-Z0-9\\s#@]", "")
+        .replaceAll("\\s+", " ")
+        .trim
 
-    // Map each hashtag to a key/value pair of (hashtag, 1) so we can count them up by adding up the values
-    val hashtagKeyValues = hashtags.map(hashtag => (hashtag, 1))
+      // Split into words
+      text.split(" ")
+        .filter(word => word.length > 2)         // Filter out very short words
+        .filter(word => !stopWords.contains(word)) // Filter out stop words
+    })
+
+    // Map each word to a key/value pair of (word, 1) so we can count them
+    val wordKeyValues = tweetwords.map(word => (word, 1))
 
     // Now count them up over the window sliding every specified interval
-    val hashtagCounts = hashtagKeyValues.reduceByKeyAndWindow((x,y) => x + y, (x,y) => x - y, windowSize, slideSize)
+    val wordCounts = wordKeyValues.reduceByKeyAndWindow((x,y) => x + y, (x,y) => x - y, windowSize, slideSize)
 
     // Sort the results by the count values
-    val sortedResults = hashtagCounts.transform(rdd => rdd.sortBy(x => x._2, false))
+    val sortedResults = wordCounts.transform(rdd => rdd.sortBy(x => x._2, false))
 
     // Print the top 10
     sortedResults.print
 
     // Set a checkpoint directory, and kick it all off
-    ssc.checkpoint("checkpoint/hashtags/")
+    ssc.checkpoint("checkpoint/words/")
     ssc.start()
     ssc.awaitTermination()
   }

--- a/src/main/scala/com/sundogsoftware/sparkstreaming/PopularHashtags.scala
+++ b/src/main/scala/com/sundogsoftware/sparkstreaming/PopularHashtags.scala
@@ -19,6 +19,15 @@ object PopularHashtags {
 
     // Configure Twitter credentials using twitter.txt
     //setupTwitter()
+
+    // Parameters for experimentation
+    // Batch size: How frequently data is processed
+    // Window size: The duration of the window (how much historical data to consider)
+    // Slide size: How frequently the window slides forward
+    val batchSize = Seconds(1)    // Try different values like 2, 5, 10 seconds
+    val windowSize = Seconds(10) // Try different values like 60, 120, 600 seconds
+    val slideSize = Seconds(10)    // Try different values like 5, 10, 30 seconds
+
     // Get rid of log spam (should be called after the context is set up)
     setupLogging()
 
@@ -26,7 +35,7 @@ object PopularHashtags {
     // all CPU cores and one-second batches of data
     val conf = new SparkConf().setAppName("PopularHashtags").setMaster("local[*]")
     val sc = new SparkContext(conf)
-    val ssc = new StreamingContext(sc, Seconds(1))
+    val ssc = new StreamingContext(sc, slideSize)
 
     // Create a queue of RDDs to stream from
     val rddQueue = new mutable.Queue[RDD[String]]()
@@ -99,10 +108,8 @@ object PopularHashtags {
     // Map each hashtag to a key/value pair of (hashtag, 1) so we can count them up by adding up the values
     val hashtagKeyValues = hashtags.map(hashtag => (hashtag, 1))
 
-    // Now count them up over a 5 minute window sliding every one second
-    val hashtagCounts = hashtagKeyValues.reduceByKeyAndWindow( (x,y) => x + y, (x,y) => x - y, Seconds(300), Seconds(1))
-    //  You will often see this written in the following shorthand:
-    //val hashtagCounts = hashtagKeyValues.reduceByKeyAndWindow( _ + _, _ -_, Seconds(300), Seconds(1))
+    // Now count them up over the window sliding every specified interval
+    val hashtagCounts = hashtagKeyValues.reduceByKeyAndWindow((x,y) => x + y, (x,y) => x - y, windowSize, slideSize)
 
     // Sort the results by the count values
     val sortedResults = hashtagCounts.transform(rdd => rdd.sortBy(x => x._2, false))

--- a/src/main/scala/com/sundogsoftware/sparkstreaming/PopularHashtags.scala
+++ b/src/main/scala/com/sundogsoftware/sparkstreaming/PopularHashtags.scala
@@ -1,60 +1,118 @@
 package com.sundogsoftware.sparkstreaming
 
 import org.apache.spark._
-import org.apache.spark.SparkContext._
 import org.apache.spark.streaming._
-import org.apache.spark.streaming.twitter._
 import org.apache.spark.streaming.StreamingContext._
 import Utilities._
+import org.apache.spark.rdd.RDD
+
+import java.io.File
+import scala.collection.mutable
 
 /** Listens to a stream of Tweets and keeps track of the most popular
  *  hashtags over a 5 minute window.
  */
 object PopularHashtags {
-  
+
   /** Our main function where the action happens */
   def main(args: Array[String]) {
 
     // Configure Twitter credentials using twitter.txt
-    setupTwitter()
-    
-    // Set up a Spark streaming context named "PopularHashtags" that runs locally using
-    // all CPU cores and one-second batches of data
-    val ssc = new StreamingContext("local[*]", "PopularHashtags", Seconds(1))
-    
+    //setupTwitter()
     // Get rid of log spam (should be called after the context is set up)
     setupLogging()
 
-    // Create a DStream from Twitter using our streaming context
-    val tweets = TwitterUtils.createStream(ssc, None)
-    
+    // Set up a Spark streaming context named "PopularHashtags" that runs locally using
+    // all CPU cores and one-second batches of data
+    val conf = new SparkConf().setAppName("PopularHashtags").setMaster("local[*]")
+    val sc = new SparkContext(conf)
+    val ssc = new StreamingContext(sc, Seconds(1))
+
+    // Create a queue of RDDs to stream from
+    val rddQueue = new mutable.Queue[RDD[String]]()
+
+    // Find all tweet directories matching the pattern
+    val rootDir = new File("checkpoint")
+
+    if (!rootDir.exists()) {
+      println(s"Directory ${rootDir.getAbsolutePath} does not exist")
+      System.exit(1)
+    }
+
+    val tweetDirs = rootDir.listFiles()
+      .filter(_.isDirectory)
+      .filter(_.getName.startsWith("Tweets_"))
+      .sortBy(_.getName)
+
+    if (tweetDirs.isEmpty) {
+      println(s"No directories matching the pattern 'Tweets_*' found in ${rootDir.getAbsolutePath}")
+      System.exit(1)
+    }
+
+    println(s"Found ${tweetDirs.length} tweet directories:")
+    tweetDirs.foreach(dir => println(s" - ${dir.getName}"))
+
+    // Collect all tweet files from all directories - looking for part-* files instead of .txt files
+    val tweetFiles = tweetDirs.flatMap { dir =>
+      val files = dir.listFiles()
+      if (files == null) {
+        println(s"Warning: Cannot access directory ${dir.getPath}")
+        Array.empty[File]
+      } else {
+        // Looking for files that start with "part-" instead of ending with ".txt"
+        val partFiles = files.filter(_.isFile).filter(_.getName.startsWith("part-"))
+        println(s"Found ${partFiles.length} tweet files in ${dir.getName}")
+        partFiles
+      }
+    }.sortBy(f => (f.getParentFile.getName, f.getName))
+
+    if (tweetFiles.isEmpty) {
+      println("No tweet files found in any directory")
+      System.exit(1)
+    }
+
+    println(s"Found ${tweetFiles.length} tweet files in total")
+
+    // Load each file into an RDD and add to the queue
+    tweetFiles.foreach { file =>
+      println(s"Loading tweets from ${file.getPath}")
+      val rdd = ssc.sparkContext.textFile(file.getPath)
+      val count = rdd.count()
+      println(s" - File contains $count tweets")
+      if (count > 0) {
+        rddQueue += rdd
+      }
+    }
+
+    // Create a DStream from the queue
+    val tweets = ssc.queueStream(rddQueue, oneAtATime = true)
+
     // Now extract the text of each status update into DStreams using map()
-    val statuses = tweets.map(status => status.getText())
-    
+    val statuses = tweets.map(status => status)
+
     // Blow out each word into a new DStream
     val tweetwords = statuses.flatMap(tweetText => tweetText.split(" "))
-    
+
     // Now eliminate anything that's not a hashtag
     val hashtags = tweetwords.filter(word => word.startsWith("#"))
-    
+
     // Map each hashtag to a key/value pair of (hashtag, 1) so we can count them up by adding up the values
     val hashtagKeyValues = hashtags.map(hashtag => (hashtag, 1))
-    
+
     // Now count them up over a 5 minute window sliding every one second
     val hashtagCounts = hashtagKeyValues.reduceByKeyAndWindow( (x,y) => x + y, (x,y) => x - y, Seconds(300), Seconds(1))
     //  You will often see this written in the following shorthand:
     //val hashtagCounts = hashtagKeyValues.reduceByKeyAndWindow( _ + _, _ -_, Seconds(300), Seconds(1))
-    
+
     // Sort the results by the count values
     val sortedResults = hashtagCounts.transform(rdd => rdd.sortBy(x => x._2, false))
-    
+
     // Print the top 10
     sortedResults.print
-    
+
     // Set a checkpoint directory, and kick it all off
-    // I could watch this all day!
-    ssc.checkpoint("C:/checkpoint/")
+    ssc.checkpoint("checkpoint/hashtags/")
     ssc.start()
     ssc.awaitTermination()
-  }  
+  }
 }

--- a/src/main/scala/com/sundogsoftware/sparkstreaming/Utilities.scala
+++ b/src/main/scala/com/sundogsoftware/sparkstreaming/Utilities.scala
@@ -13,15 +13,59 @@ object Utilities {
   }
   
   /** Configures Twitter service credentials using twitter.txt in the data directory */
-  def setupTwitter() = {
+  def setupTwitter(): Unit = {
     import scala.io.Source
-    
-    for (line <- Source.fromFile("data/twitter.txt").getLines) {
-      val fields = line.split(" ")
-      if (fields.length == 2) {
-        System.setProperty("twitter4j.oauth." + fields(0), fields(1))
-      }
+    import org.apache.http.client.methods.HttpPost
+    import org.apache.http.impl.client.HttpClients
+    import org.apache.http.util.EntityUtils
+    import org.apache.http.message.BasicNameValuePair
+    import org.apache.http.client.entity.UrlEncodedFormEntity
+    import java.util.{ArrayList, Base64}
+    import java.nio.charset.StandardCharsets
+
+    val file = new java.io.File("data/twitter.txt")
+    if (!file.exists()) throw new Exception("File data/twitter.txt not found")
+
+    // Read credentials from file
+    val lines = Source.fromFile(file).getLines().toList
+    val key = lines.find(_.startsWith("consumerKey=")).map(_.split("=")(1)).orNull
+    val secret = lines.find(_.startsWith("consumerSecret=")).map(_.split("=")(1)).orNull
+
+    if (key == null || secret == null)
+      throw new Exception("Twitter credentials not found in expected format")
+
+    // For compatibility with existing Twitter4J code
+    val accessToken = lines.find(_.startsWith("accessToken=")).map(_.split("=")(1)).orNull
+    val accessTokenSecret = lines.find(_.startsWith("accessTokenSecret=")).map(_.split("=")(1)).orNull
+
+    if (accessToken != null && accessTokenSecret != null) {
+      System.setProperty("twitter4j.oauth.consumerKey", key)
+      System.setProperty("twitter4j.oauth.consumerSecret", secret)
+      System.setProperty("twitter4j.oauth.accessToken", accessToken)
+      System.setProperty("twitter4j.oauth.accessTokenSecret", accessTokenSecret)
     }
+
+    // Generate and store bearer token for Twitter API v2
+    val client = HttpClients.createDefault()
+    val post = new HttpPost("https://api.twitter.com/oauth2/token")
+    val credentials = Base64.getEncoder.encodeToString(s"$key:$secret".getBytes(StandardCharsets.UTF_8))
+
+    post.addHeader("Authorization", s"Basic $credentials")
+    post.addHeader("Content-Type", "application/x-www-form-urlencoded;charset=UTF-8")
+    post.setEntity(new UrlEncodedFormEntity(new ArrayList[BasicNameValuePair]() {
+      add(new BasicNameValuePair("grant_type", "client_credentials"))
+    }))
+
+    val response = client.execute(post)
+    val responseString = EntityUtils.toString(response.getEntity, "UTF-8")
+
+    val bearerToken = scala.util.parsing.json.JSON.parseFull(responseString) match {
+      case Some(map: Map[String, Any]) => map("access_token").toString
+      case _ => throw new Exception("Failed to obtain bearer token")
+    }
+
+    // Store the bearer token for use by other components
+    System.setProperty("twitter.bearer.token", bearerToken)
   }
   
   /** Retrieves a regex Pattern for parsing Apache access logs. */


### PR DESCRIPTION
This pull request refactors and enhances the Spark Streaming applications to improve modularity, replace live Twitter streaming with file-based input, and update the Twitter API integration. Key changes include migrating to file-based tweet processing, adding a new application for tracking the longest tweet length, and modernizing the `setupTwitter` utility to support Twitter API v2.

### Refactoring and Enhancements to Spark Streaming Applications:

* **File-based tweet processing**: Replaced live Twitter streaming with file-based input across all applications (`AverageTweetLength`, `LongestTweetLength`, and `PopularHashtags`). This includes reading tweet files from directories, filtering for `part-*` files, and creating RDD queues for streaming. [[1]](diffhunk://#diff-d472c329e9329844526cc259f6a74319018003d3e4eb0865b26862d5a695b947R20-R108) [[2]](diffhunk://#diff-a6e3cc86de479f8e9d5ee7ed5ced7cc05e8955c1bf394ece7beffef8de777535R1-R120) [[3]](diffhunk://#diff-b7377b722094d666c92357eba38c54d101b1a51e6c3026df4e03ff6a491b411dL4-R135)

* **New application - `LongestTweetLength`**: Added a new application to compute the longest tweet length in a stream using thread-safe counters and file-based input.

* **Refactored `PopularHashtags`**: Changed focus from hashtags to general word frequency, added stop-word filtering, and introduced configurable batch, window, and slide sizes for experimentation.

### Updates to Utilities:

* **Modernized `setupTwitter`**: Updated the `setupTwitter` method to support Twitter API v2 by generating and storing a bearer token. This ensures compatibility with the latest API standards while retaining backward compatibility for Twitter4J.