### PR TITLE
Feature: Update checkpoint location for structured streaming

### DIFF
--- a/src/main/scala/com/sundogsoftware/sparkstreaming/StructuredStreaming.scala
+++ b/src/main/scala/com/sundogsoftware/sparkstreaming/StructuredStreaming.scala
@@ -64,8 +64,8 @@ object StructuredStreaming {
         .builder
         .appName("StructuredStreaming")
         .master("local[*]")
-        .config("spark.sql.warehouse.dir", "file:///C:/temp") // Necessary to work around a Windows bug in Spark 2.0.0; omit if you're not on Windows.
-        .config("spark.sql.streaming.checkpointLocation", "file:///C:/checkpoint")
+        //.config("spark.sql.warehouse.dir", "file:///C:/temp") // Necessary to work around a Windows bug in Spark 2.0.0; omit if you're not on Windows.
+        .config("spark.sql.streaming.checkpointLocation", "checkpoint/StructeredStreaming/") // Necessary to set a checkpoint location for structured streaming
         .getOrCreate()
         
       setupLogging()


### PR DESCRIPTION
This pull request updates the configuration settings for structured streaming in the `StructuredStreaming.scala` file. The most significant change involves modifying the checkpoint location to use a relative path instead of an absolute path.

Configuration updates:

* [`src/main/scala/com/sundogsoftware/sparkstreaming/StructuredStreaming.scala`](diffhunk://#diff-304e1736b9c2f36d0c512c2120f4169dd45e4e40e1d30af4304a978f7dc4bcd9L67-R68): Changed the `spark.sql.streaming.checkpointLocation` configuration to use a relative path (`checkpoint/StructeredStreaming/`) instead of an absolute path (`file:///C:/checkpoint`). This aligns the checkpoint location with structured streaming requirements.