### PR TITLE
Feature: Update checkpoint directory for CustomReceiverExample.

### DIFF
--- a/src/main/scala/com/sundogsoftware/sparkstreaming/CustomReceiverExample.scala
+++ b/src/main/scala/com/sundogsoftware/sparkstreaming/CustomReceiverExample.scala
@@ -96,7 +96,7 @@ object CustomReceiverExample {
     sortedResults.print()
     
     // Kick it off
-    ssc.checkpoint("C:/checkpoint/")
+    ssc.checkpoint("checkpoint/CustomReceiverExample/")
     ssc.start()
     ssc.awaitTermination()
   }


### PR DESCRIPTION
This pull request updates the checkpoint directory in the `CustomReceiverExample` Spark Streaming application to use a more specific path.

* [`src/main/scala/com/sundogsoftware/sparkstreaming/CustomReceiverExample.scala`](diffhunk://#diff-f8042b0be01d3555a6375f2297e73766446ecec0c053ea63b2a302fdd724f10cL99-R99): Changed the checkpoint directory from `"C:/checkpoint/"` to `"checkpoint/CustomReceiverExample/"` to better align with the application's context.nc -kl 7777 < access_log.txt