### PR TITLE
Feature/sessionizer

### DIFF
--- a/src/main/scala/com/sundogsoftware/sparkstreaming/Sessionizer.scala
+++ b/src/main/scala/com/sundogsoftware/sparkstreaming/Sessionizer.scala
@@ -22,25 +22,41 @@ object Sessionizer {
    *  which makes up the session data state that we want to preserve across a given session. The "case class" automatically
    *  creates the constructor and accessors we want to use.
    */
-  case class SessionData(val sessionLength: Long, var clickstream:List[String]);
+  case class SessionData(val sessionLength: Long, var clickstream:List[String], var successCodes: Long = 0, var errorCodes: Long = 0);
   
   /** This function gets called as new data is streamed in, and maintains state across whatever key you define. In this case,
    *  it expects to get an IP address as the key, a String as a URL (wrapped in an Option to handle exceptions), and 
    *  maintains state defined by our SessionData class defined above. Its output is new key, value pairs of IP address
    *  and the updated SessionData that takes this new line into account.
    */
-  def trackStateFunc(batchTime: Time, ip: String, url: Option[String], state: State[SessionData]): Option[(String, SessionData)] = {
-    // Extract the previous state passed in (using getOrElse to handle exceptions)
-    val previousState = state.getOption.getOrElse(SessionData(0, List()))
-    
-    // Create a new state that increments the session length by one, adds this URL to the clickstream, and clamps the clickstream 
-    // list to 10 items
-    val newState = SessionData(previousState.sessionLength + 1L, (previousState.clickstream :+ url.getOrElse("empty")).take(10))
-    
-    // Update our state with the new state.
+  def trackStateFunc(batchTime: Time, ip: String, urlAndStatus: Option[(String, String)],
+                     state: State[SessionData]): Option[(String, SessionData)] = {
+    // Extract the previous state passed in
+    val previousState = state.getOption.getOrElse(SessionData(0, List(), 0, 0))
+
+    // Extract URL and status code
+    val (url, statusCode) = urlAndStatus.getOrElse(("empty", "0"))
+
+    // Determine if status code indicates success (2xx, 3xx) or error (4xx, 5xx)
+    val isSuccess = try {
+      val code = statusCode.toInt
+      code >= 200 && code < 400
+    } catch {
+      case _: Exception => false
+    }
+
+    // Create a new state with updated counters
+    val newState = SessionData(
+      previousState.sessionLength + 1L,
+      (previousState.clickstream :+ url).take(10),
+      previousState.successCodes + (if (isSuccess) 1L else 0L),
+      previousState.errorCodes + (if (!isSuccess) 1L else 0L)
+    )
+
+    // Update our state
     state.update(newState)
-    
-    // Return a new key/value result.
+
+    // Return a new key/value result
     Some((ip, newState))
   }
   
@@ -63,15 +79,16 @@ object Sessionizer {
     
     // Extract the (ip, url) we want from each log line
     val requests = lines.map(x => {
-      val matcher:Matcher = pattern.matcher(x)
+      val matcher: Matcher = pattern.matcher(x)
       if (matcher.matches()) {
         val ip = matcher.group(1)
         val request = matcher.group(5)
+        val statusCode = matcher.group(6) // Extract status code
         val requestFields = request.toString().split(" ")
         val url = scala.util.Try(requestFields(1)) getOrElse "[error]"
-        (ip, url)
+        (ip, (url, statusCode)) // Return IP, URL, and status code as tuple
       } else {
-        ("error", "error")
+        ("error", ("error", "0"))
       }
     })
     
@@ -101,7 +118,12 @@ object Sessionizer {
       // without having to use an intermediate case class to define your records.
       // Our RDD contains key/value pairs of IP address to SessionData objects (the output from
       // trackStateFunc), so we first split it into 3 columns using map().
-      val requestsDataFrame = rdd.map(x => (x._1, x._2.sessionLength, x._2.clickstream)).toDF("ip", "sessionLength", "clickstream")
+      val requestsDataFrame = rdd.map(x => (x._1,
+                                            x._2.sessionLength,
+                                            x._2.clickstream,
+                                            x._2.successCodes,
+                                            x._2.errorCodes))
+        .toDF("ip", "sessionLength", "clickstream", "successCodes", "errorCodes")
 
       // Create a SQL table from this DataFrame
       requestsDataFrame.createOrReplaceTempView("sessionData")

--- a/src/main/scala/com/sundogsoftware/sparkstreaming/Sessionizer.scala
+++ b/src/main/scala/com/sundogsoftware/sparkstreaming/Sessionizer.scala
@@ -115,7 +115,7 @@ object Sessionizer {
     })
     
     // Kick it off
-    ssc.checkpoint("C:/checkpoint/")
+    ssc.checkpoint("checkpoint/Sessionizer/")
     ssc.start()
     ssc.awaitTermination()
   }


### PR DESCRIPTION
This pull request enhances the `Sessionizer` functionality in `src/main/scala/com/sundogsoftware/sparkstreaming/Sessionizer.scala` by adding support for tracking HTTP status codes and improving session data. The changes include updates to the `SessionData` case class, modifications to the state tracking function, and adjustments to the data extraction and processing logic.

### Enhancements to session tracking:

* **Updated `SessionData` case class**: Added `successCodes` and `errorCodes` fields to track HTTP status code counts within a session.
* **Enhanced `trackStateFunc` function**: Modified to handle tuples of URL and status code, updated logic to classify status codes as success or error, and increment respective counters in the session state.

### Improvements to data extraction:

* **Modified log parsing**: Updated logic to extract HTTP status codes and return them as part of the tuple alongside the URL.

### Adjustments to data processing:

* **Updated DataFrame creation**: Included `successCodes` and `errorCodes` in the DataFrame schema for SQL queries.

### Other changes:

* **Checkpoint directory update**: Changed the checkpoint directory path to a more descriptive location.