### PR TITLE
Feature/regression

### DIFF
--- a/src/main/scala/com/sundogsoftware/sparkstreaming/Sessionizer.scala
+++ b/src/main/scala/com/sundogsoftware/sparkstreaming/Sessionizer.scala
@@ -22,25 +22,41 @@ object Sessionizer {
    *  which makes up the session data state that we want to preserve across a given session. The "case class" automatically
    *  creates the constructor and accessors we want to use.
    */
-  case class SessionData(val sessionLength: Long, var clickstream:List[String]);
+  case class SessionData(val sessionLength: Long, var clickstream:List[String], var successCodes: Long = 0, var errorCodes: Long = 0);
   
   /** This function gets called as new data is streamed in, and maintains state across whatever key you define. In this case,
    *  it expects to get an IP address as the key, a String as a URL (wrapped in an Option to handle exceptions), and 
    *  maintains state defined by our SessionData class defined above. Its output is new key, value pairs of IP address
    *  and the updated SessionData that takes this new line into account.
    */
-  def trackStateFunc(batchTime: Time, ip: String, url: Option[String], state: State[SessionData]): Option[(String, SessionData)] = {
-    // Extract the previous state passed in (using getOrElse to handle exceptions)
-    val previousState = state.getOption.getOrElse(SessionData(0, List()))
-    
-    // Create a new state that increments the session length by one, adds this URL to the clickstream, and clamps the clickstream 
-    // list to 10 items
-    val newState = SessionData(previousState.sessionLength + 1L, (previousState.clickstream :+ url.getOrElse("empty")).take(10))
-    
-    // Update our state with the new state.
+  def trackStateFunc(batchTime: Time, ip: String, urlAndStatus: Option[(String, String)],
+                     state: State[SessionData]): Option[(String, SessionData)] = {
+    // Extract the previous state passed in
+    val previousState = state.getOption.getOrElse(SessionData(0, List(), 0, 0))
+
+    // Extract URL and status code
+    val (url, statusCode) = urlAndStatus.getOrElse(("empty", "0"))
+
+    // Determine if status code indicates success (2xx, 3xx) or error (4xx, 5xx)
+    val isSuccess = try {
+      val code = statusCode.toInt
+      code >= 200 && code < 400
+    } catch {
+      case _: Exception => false
+    }
+
+    // Create a new state with updated counters
+    val newState = SessionData(
+      previousState.sessionLength + 1L,
+      (previousState.clickstream :+ url).take(10),
+      previousState.successCodes + (if (isSuccess) 1L else 0L),
+      previousState.errorCodes + (if (!isSuccess) 1L else 0L)
+    )
+
+    // Update our state
     state.update(newState)
-    
-    // Return a new key/value result.
+
+    // Return a new key/value result
     Some((ip, newState))
   }
   
@@ -63,15 +79,16 @@ object Sessionizer {
     
     // Extract the (ip, url) we want from each log line
     val requests = lines.map(x => {
-      val matcher:Matcher = pattern.matcher(x)
+      val matcher: Matcher = pattern.matcher(x)
       if (matcher.matches()) {
         val ip = matcher.group(1)
         val request = matcher.group(5)
+        val statusCode = matcher.group(6) // Extract status code
         val requestFields = request.toString().split(" ")
         val url = scala.util.Try(requestFields(1)) getOrElse "[error]"
-        (ip, url)
+        (ip, (url, statusCode)) // Return IP, URL, and status code as tuple
       } else {
-        ("error", "error")
+        ("error", ("error", "0"))
       }
     })
     
@@ -101,7 +118,12 @@ object Sessionizer {
       // without having to use an intermediate case class to define your records.
       // Our RDD contains key/value pairs of IP address to SessionData objects (the output from
       // trackStateFunc), so we first split it into 3 columns using map().
-      val requestsDataFrame = rdd.map(x => (x._1, x._2.sessionLength, x._2.clickstream)).toDF("ip", "sessionLength", "clickstream")
+      val requestsDataFrame = rdd.map(x => (x._1,
+                                            x._2.sessionLength,
+                                            x._2.clickstream,
+                                            x._2.successCodes,
+                                            x._2.errorCodes))
+        .toDF("ip", "sessionLength", "clickstream", "successCodes", "errorCodes")
 
       // Create a SQL table from this DataFrame
       requestsDataFrame.createOrReplaceTempView("sessionData")

--- a/src/main/scala/com/sundogsoftware/sparkstreaming/Sessionizer.scala
+++ b/src/main/scala/com/sundogsoftware/sparkstreaming/Sessionizer.scala
@@ -115,7 +115,7 @@ object Sessionizer {
     })
     
     // Kick it off
-    ssc.checkpoint("C:/checkpoint/")
+    ssc.checkpoint("checkpoint/Sessionizer/")
     ssc.start()
     ssc.awaitTermination()
   }

--- a/src/main/scala/com/sundogsoftware/sparkstreaming/StreamingKMeansExample.scala
+++ b/src/main/scala/com/sundogsoftware/sparkstreaming/StreamingKMeansExample.scala
@@ -56,7 +56,7 @@ object StreamingKMeansExample {
     model.predictOnValues(testData.map(lp => (lp.label.toInt, lp.features))).print()
     
     // Kick it off
-    ssc.checkpoint("C:/checkpoint/")
+    ssc.checkpoint("checkpoint/KMeansExample/")
     ssc.start()
     ssc.awaitTermination()
   }

--- a/src/main/scala/com/sundogsoftware/sparkstreaming/StreamingRegression.scala
+++ b/src/main/scala/com/sundogsoftware/sparkstreaming/StreamingRegression.scala
@@ -60,7 +60,7 @@ object StreamingRegression {
     model.predictOnValues(testData.map(lp => (lp.label, lp.features))).print()
     
     // Kick it off
-    ssc.checkpoint("C:/checkpoint/")
+    ssc.checkpoint("checkpoint/Regression/")
     ssc.start()
     ssc.awaitTermination()
   }


### PR DESCRIPTION
This pull request introduces enhancements to the `Sessionizer` functionality by adding success and error code tracking, alongside updates to checkpoint paths across multiple streaming examples. The most significant changes include modifications to the `SessionData` case class, updates to the state tracking logic, and adjustments to the checkpoint directories for better organization.

### Enhancements to `Sessionizer` functionality:

* **Extended `SessionData` case class**: Added `successCodes` and `errorCodes` fields to track counts of successful and erroneous HTTP status codes.
* **Updated state tracking logic**: Modified `trackStateFunc` to handle HTTP status codes, updating counters for success (2xx, 3xx) and error (4xx, 5xx) codes, and adjusted the tuple returned to include the status code. [[1]](diffhunk://#diff-3f9b8a5c2a95b8d8b29dcff4cd1724daafe7cf896f7c02f18e00548cad183d32L25-R59) [[2]](diffhunk://#diff-3f9b8a5c2a95b8d8b29dcff4cd1724daafe7cf896f7c02f18e00548cad183d32R86-R91)
* **Enhanced DataFrame creation**: Added `successCodes` and `errorCodes` columns to the DataFrame for SQL analysis.

### Checkpoint path updates:

* **Improved checkpoint organization in `Sessionizer`**: Changed checkpoint directory to `checkpoint/Sessionizer/`.
* **Standardized checkpoint paths in other examples**: Updated checkpoint directories in `StreamingKMeansExample` and `StreamingRegression` to `checkpoint/KMeansExample/` and `checkpoint/Regression/`, respectively. [[1]](diffhunk://#diff-bd313b6581e592dc9330314a2e0c33a4c5dbb7365090f5fa3156f38144901fdeL59-R59) [[2]](diffhunk://#diff-1a3c9110b92a2095be38faac8efdcbd68aae6424e442b9f43630039fe69a5198L63-R63)